### PR TITLE
Added support for '!' command in shell

### DIFF
--- a/user/sh.c
+++ b/user/sh.c
@@ -74,8 +74,13 @@ runcmd(struct cmd *cmd)
 
   case EXEC:
     ecmd = (struct execcmd*)cmd;
-    if(ecmd->argv[0] == 0)
-      exit(1);
+    if (ecmd->argv[0] && strcmp(ecmd->argv[0], "!") == 0) {
+    for (int i = 1; ecmd->argv[i]; i++) {
+        fprintf(2, "%s ", ecmd->argv[i]);
+      }
+    fprintf(2, "\n");
+    exit(0);
+    }
     exec(ecmd->argv[0], ecmd->argv);
     fprintf(2, "exec %s failed\n", ecmd->argv[0]);
     break;


### PR DESCRIPTION
This PR adds the basic implementation of the '!' command in the shell.

### Implemented Features:
✅ The shell now recognizes the '!' command.  
✅ The message after '!' is printed correctly.  

### Remaining Work:
🔹 Limit message length to 512 bytes.  
🔹 Detect the word "os" and print it in blue.  
🔹 Additional error handling if needed.

