### PR TITLE
Add trigger syscall and logging functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+        $U/_trigger_test\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_trigger(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_trigger] sys_trigger,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_trigger 22

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -5,6 +5,7 @@
 #include "memlayout.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "custom_logger.h"
 
 uint64
 sys_exit(void)
@@ -90,4 +91,11 @@ sys_uptime(void)
   xticks = ticks;
   release(&tickslock);
   return xticks;
+}
+
+uint64
+sys_trigger(void)
+{
+  log_message(INFO, "This is a log to test a new xv6 system call");
+  return 0;
 }

--- a/user/trigger_test.c
+++ b/user/trigger_test.c
@@ -1,0 +1,9 @@
+#include "kernel/types.h"
+#include "user/user.h"
+#include "kernel/custom_logger.h"
+
+int main(int argc, char *argv[])
+{
+  trigger();
+  exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int trigger(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("trigger");


### PR DESCRIPTION
### Summary
This pull request introduces a new system call named `trigger` to the xv6 operating system.

### Changes
- Added a new syscall `trigger` that logs the following message to the kernel log:
INFO - This is a log to test a new xv6 system call

- Updated syscall table and dispatch mechanisms
- Created a user-level test program `testtrigger` to verify functionality

### Base Branch
Merging `develop` → `main`

### Notes
- Tested in QEMU environment
- Log output successfully appears on invocation of the syscall
